### PR TITLE
Fix rubocop issues following update

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -11,7 +11,7 @@ Bundler::GemHelper.install_tasks
 # This is wrapped to prevent an error when rake is called in environments where
 # rspec may not be available, e.g. production. As such we don't need to handle
 # the error.
-# rubocop:disable Lint/HandleExceptions
+# rubocop:disable Lint/SuppressedException
 begin
   require "rspec/core/rake_task"
 
@@ -32,4 +32,4 @@ begin
 rescue LoadError
   # no changelog available
 end
-# rubocop:enable Lint/HandleExceptions
+# rubocop:enable Lint/SuppressedException


### PR DESCRIPTION
It looks like rubocop 0.78 has changed the name of the cop for handling exceptions, making a more specific one for when exceptions are suppressed.

This resolves the issues with the build, and should get Travis green again.