### PR TITLE
Use WEX and WCR compatible Airbrake version

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,16 @@ It's aim is to help us
 
 ## Installation
 
-Add this line to your application's Gemfile
+This gem is intended to replace directly referencing and managing the [Airbrake gem](https://github.com/airbrake/airbrake-ruby) in our services. However our services require different versions of Airbrake due to the versions of Ruby they depend on. So if like the [Flood Risk Activity Exemptions service](https://github.com/DEFRA/ruby-services-team/tree/master/services/frae) you are using Ruby 2.3 and need Airbrake version 5.3 add this line to your application's Gemfile
 
 ```ruby
-gem "defra_ruby_alert"
+gem "defra_ruby_alert", "~> 0.1.0"
+```
+
+If like the [Waste Exemptions](https://github.com/DEFRA/ruby-services-team/tree/master/services/wex) and [Waste Carriers](https://github.com/DEFRA/ruby-services-team/tree/master/services/wcr) services you are using Ruby 2.4 and need Airbrake version 5.8 add this line to your application's Gemfile
+
+```ruby
+gem "defra_ruby_alert", "~> 1.0.0"
 ```
 
 And then update your dependencies by calling

--- a/defra_ruby_alert.gemspec
+++ b/defra_ruby_alert.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   end
 
   # Alert catches exceptions, sends them to our Errbit instances
-  spec.add_dependency "airbrake", "~> 5.3.0"
+  spec.add_dependency "airbrake", "~> 5.8.1"
 
   spec.add_development_dependency "defra_ruby_style"
   # Shim to load environment variables from a .env file into ENV

--- a/lib/defra_ruby/alert/version.rb
+++ b/lib/defra_ruby/alert/version.rb
@@ -2,6 +2,6 @@
 
 module DefraRuby
   module Alert
-    VERSION = "0.1.0"
+    VERSION = "1.0.0"
   end
 end


### PR DESCRIPTION
When this gem was first put together to solve [a problem](https://github.com/DEFRA/flood-risk-engine/pull/312) in the [Flood Risk Activity service](https://github.com/DEFRA/ruby-services-team/tree/master/services/frae) it needed to stick with a version of Airbrake that was compatible to FRAE. In fact it was needing to use an older version, and the problem that caused implementing our `Airbrake.close` pattern that sparked the idea of creating this gem.

We now want to start using this gem in our other services [Waste Carriers](https://github.com/DEFRA/ruby-services-team/tree/master/services/wcr) and [Waste Exemptions](https://github.com/DEFRA/ruby-services-team/tree/master/services/wex) but they use a later 5.8 version of Airbrake.

So to support this we'll bump the version of Airbrake used in this change, as well as bumping the version of this gem to 1.0.

That way FRAE can be set to pull the 0.1.x versions of the gem, and the rest of our services can pull the 1.x versions.