### PR TITLE
Rename blacklist to blocklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Currently there are a number of Rails based digital services in Defra, all of wh
 
 This means we are often duplicating the code to configure and manage Airbrake across them. So we created this gem 😁!
 
-It's aim is to help us
+Its aim is to help us
 
 - start to reduce the duplication across projects
 - be consistent in how we configure and manage Airbrake
@@ -73,17 +73,17 @@ The gem has been designed to be used by our Rails apps, so we would also expect 
   config.environment = Rails.env
 ```
 
-### blacklist
+### blocklist
 
 > Specifies which keys in the payload (parameters, session data, environment data, etc) should be filtered. Before sending an error, filtered keys will be substituted with the [Filtered] label.
 
-Not every project uses this, but some do hence we provide the ability to specify a blacklist.
+Not every project uses this, but some do hence we provide the ability to specify a blocklist.
 
 ```ruby
-  config.blacklist = [/password/i, /postcode/i, :name]
+  config.blocklist = [/password/i, /postcode/i, :name]
 ```
 
-See Airbrake's [blacklist_keys](https://github.com/airbrake/airbrake-ruby#blacklist_keys) for more details.
+See Airbrake's [blocklist_keys](https://github.com/airbrake/airbrake-ruby#blocklist_keys) for more details.
 
 ## Usage
 

--- a/lib/defra_ruby/alert/airbrake_runner.rb
+++ b/lib/defra_ruby/alert/airbrake_runner.rb
@@ -62,8 +62,8 @@ module DefraRuby
           # A list of parameters that should be filtered out of what is sent to
           # Airbrake. By default, all "password" attributes will have their contents
           # replaced.
-          # https://github.com/airbrake/airbrake-ruby#blacklist_keys
-          c.blacklist_keys = DefraRuby::Alert.configuration.blacklist
+          # https://github.com/airbrake/airbrake-ruby#blocklist_keys
+          c.blocklist_keys = DefraRuby::Alert.configuration.blocklist
         end
       end
     end

--- a/lib/defra_ruby/alert/configuration.rb
+++ b/lib/defra_ruby/alert/configuration.rb
@@ -4,10 +4,10 @@ module DefraRuby
   module Alert
     class Configuration
       attr_accessor :root_directory, :logger, :environment
-      attr_accessor :host, :project_key, :blacklist, :enabled
+      attr_accessor :host, :project_key, :blocklist, :enabled
 
       def initialize
-        @blacklist = []
+        @blocklist = []
         @enabled = false
       end
     end

--- a/spec/defra_ruby/alert/airbrake_runner_spec.rb
+++ b/spec/defra_ruby/alert/airbrake_runner_spec.rb
@@ -20,7 +20,7 @@ module DefraRuby
           :logger= => nil,
           :environment= => nil,
           :ignore_environments= => nil,
-          :blacklist_keys= => nil
+          :blocklist_keys= => nil
         )
 
         allow(Airbrake).to receive(:configure).and_yield(configuration)

--- a/spec/defra_ruby/alert/configuration_spec.rb
+++ b/spec/defra_ruby/alert/configuration_spec.rb
@@ -14,7 +14,7 @@ module DefraRuby
 
         expect(fresh_config.host).to be_nil
         expect(fresh_config.project_key).to be_nil
-        expect(fresh_config.blacklist).to eq([])
+        expect(fresh_config.blocklist).to eq([])
         expect(fresh_config.enabled).to eq(false)
       end
     end


### PR DESCRIPTION
Airbrake has quite rightly changed this term to blocklist: https://github.com/airbrake/airbrake-ruby/pull/580

So this PR updates our gem to deal with it.