### PR TITLE
Disable performance stats

### DIFF
--- a/lib/defra_ruby/alert/airbrake_runner.rb
+++ b/lib/defra_ruby/alert/airbrake_runner.rb
@@ -64,6 +64,13 @@ module DefraRuby
           # replaced.
           # https://github.com/airbrake/airbrake-ruby#blocklist_keys
           c.blocklist_keys = DefraRuby::Alert.configuration.blocklist
+
+          # Latest versions of Airbrake support performance stats being
+          # automatically sent to Airbrake. We actually use Errbit at Defra
+          # which doesn't support this feature. So all we see is lots of 404
+          # errors in our logs. To prevent this we disable this feature.
+          # https://github.com/airbrake/airbrake-ruby#performance_stats
+          c.performance_stats = false
         end
       end
     end

--- a/lib/defra_ruby/alert/configuration.rb
+++ b/lib/defra_ruby/alert/configuration.rb
@@ -3,8 +3,7 @@
 module DefraRuby
   module Alert
     class Configuration
-      attr_accessor :root_directory, :logger, :environment
-      attr_accessor :host, :project_key, :blocklist, :enabled
+      attr_accessor :root_directory, :logger, :environment, :host, :project_key, :blocklist, :enabled
 
       def initialize
         @blocklist = []

--- a/spec/defra_ruby/alert/airbrake_runner_spec.rb
+++ b/spec/defra_ruby/alert/airbrake_runner_spec.rb
@@ -20,8 +20,10 @@ module DefraRuby
           :logger= => nil,
           :environment= => nil,
           :ignore_environments= => nil,
-          :blocklist_keys= => nil
+          :blocklist_keys= => nil,
+          :performance_stats= => nil,
         )
+        allow(configuration).to receive(:performance_stats)
 
         allow(Airbrake).to receive(:configure).and_yield(configuration)
       end

--- a/spec/defra_ruby/alert/airbrake_runner_spec.rb
+++ b/spec/defra_ruby/alert/airbrake_runner_spec.rb
@@ -21,7 +21,7 @@ module DefraRuby
           :environment= => nil,
           :ignore_environments= => nil,
           :blocklist_keys= => nil,
-          :performance_stats= => nil,
+          :performance_stats= => nil
         )
         allow(configuration).to receive(:performance_stats)
 


### PR DESCRIPTION
Since we updated to the latest Airbrake in PR #8 we've spotted we get a warning output to the log.

```
**Airbrake: Airbrake::PerformanceNotifier#send: {"routes"=>[{"method"=>"POST", "route"=>"/bo/users/sign_in(.:format)", "statusCode"=>302, "time"=>"2020-07-09T08:36:00+00:00", "count"=>1, "sum"=>263.321214, "sumsq"=>69338.0617424338, "tdigest"=>"AAAAAkA0AAAAAAAAAAAAAUODqR4B"}, {"method"=>"GET", "route"=>"/bo(.:format)", "statusCode"=>200, "time"=>"2020-07-09T08:36:00+00:00", "count"=>1, "sum"=>6908.626037, "sumsq"=>47729113.719114326, "tdigest"=>"AAAAAkA0AAAAAAAAAAAAAUXX5QIB"}], "environment"=>"development"}
**Airbrake: Airbrake::PerformanceNotifier#send: {"routes"=>[{"method"=>"GET", "route"=>"/bo(.:format)", "responseType"=>:html, "time"=>"2020-07-09T08:36:00+00:00", "count"=>1, "sum"=>6908.827549, "sumsq"=>47731898.10182134, "tdigest"=>"AAAAAkA0AAAAAAAAAAAAAUXX5p8B", "groups"=>{:view=>{"count"=>1, "sum"=>6744.80324400065, "sumsq"=>45492370.80028169, "tdigest"=>"AAAAAkA0AAAAAAAAAAAAAUXSxm0B"}}}], "environment"=>"development"}
**Airbrake: unexpected code (404). Body: <!DOCTYPE html>
<html>
<head>
  <title>The page you were looking for doesn't exist (404)</title>
  <s...
**Airbrake: unexpected code (404). Body: <!DOCTYPE html>
<html>
<head>
  <title>The page you were looking for doesn't exist (404)</title>
  <s...
```

From looking at the docs Airbrake added [Performance monitoring](https://github.com/airbrake/airbrake-ruby#performance_stats) to the gem and have it enabled by default. We actually send out results to Errbit which does not support collecting this info hence the 404.

So to stop Airbrake trying to do this on each page we need to disable the performance monitoring option in the gem.